### PR TITLE
Extend skill.json spec

### DIFF
--- a/docs/skill_json.md
+++ b/docs/skill_json.md
@@ -11,6 +11,9 @@ This file contains metadata about the skill and all info about how to install an
   "skill_id": "skill-XXX.exampleauthor",
   "source": "https://github.com/ExampleAuthor/skill-XXX",
   "package_name": "ovos-skill-XXX",
+  "pip_spec": "git+https://github.com/ExampleAuthor/skill-XXX@BRANCH",
+  "license": "Apache-2.0",
+  "author": "ExampleAuthor",
   "extra_plugins": {
     "core": ["ovos-utterance-transformer-XXX"],
     "PHAL": ["ovos-PHAL-XXX"],
@@ -38,8 +41,11 @@ This file contains metadata about the skill and all info about how to install an
 On the JSON file:
 
 * `skill_id` refers to the unique skill identifier, this is defined in `setup.py` and by convention is usually `repo.author` (lower-cased)
-* `source` git url to download the source code, a skill can be installed from source with `pip install git+{source}`
+* `source` Optional git url to download the source code, a skill can be installed from source with `pip install git+{source}`
 * `package_name` the package name of the skill, if the skill is on pypi it can be installed with `pip install {package_name}`
+* `pip_spec` Optional [PEP 508](https://peps.python.org/pep-0508/#specification) install spec to install the skill. `pip install pip_spec`
+* `license` Optional [SPDX License ID](https://spdx.org/licenses/)
+* `author` Optional string author name. Overrides any name extracted from `skill_id` or `source` URL
 * `extra_plugins` list of python requirements that are not direct dependencies of the skill but should be installed in a companion OVOS service
 * `name` is a human-readable name for the skill to be used in store listings, UI, etc.
 * `description` is a human-readable short description of the skill. This should be limited to one or two sentences max
@@ -48,4 +54,7 @@ On the JSON file:
 * `icon` optional skill icon to display
 * `images` optional list of images to showcase the skill
 
+> Installation will generally follow the priority of `<pip_spec>` > `<package_name>` > `git+<source>`
+
 > **LANG SUPPORT**: include `skill.json` in each lang subfolder of your `locale` skill directory, this signals language support and allows translation of `name`, `description`, `examples` and `tags`
+

--- a/docs/skill_json.md
+++ b/docs/skill_json.md
@@ -54,7 +54,7 @@ On the JSON file:
 * `icon` optional skill icon to display
 * `images` optional list of images to showcase the skill
 
-> Installation will generally follow the priority of `<pip_spec>` > `<package_name>` > `git+<source>`
+> Installation will generally follow the priority of `<pip_spec>` > `<package_name>` > `git+<source>`. At least one of these *MUST* be a valid installation option
 
 > **LANG SUPPORT**: include `skill.json` in each lang subfolder of your `locale` skill directory, this signals language support and allows translation of `name`, `description`, `examples` and `tags`
 

--- a/docs/skill_json.md
+++ b/docs/skill_json.md
@@ -40,21 +40,42 @@ This file contains metadata about the skill and all info about how to install an
 
 On the JSON file:
 
-* `skill_id` refers to the unique skill identifier, this is defined in `setup.py` and by convention is usually `repo.author` (lower-cased)
+* `skill_id` Required unique skill identifier, this is defined in `setup.py` and by convention is usually `repo.author` (lower-cased)
 * `source` Optional git url to download the source code, a skill can be installed from source with `pip install git+{source}`
-* `package_name` the package name of the skill, if the skill is on pypi it can be installed with `pip install {package_name}`
-* `pip_spec` Optional [PEP 508](https://peps.python.org/pep-0508/#specification) install spec to install the skill. `pip install pip_spec`
+* `package_name` Required package name of the skill, if the skill is on pypi it can be installed with `pip install {package_name}`
+* `pip_spec` Optional [PEP 508](https://peps.python.org/pep-0508/#specification) install spec to install the skill. `pip install {pip_spec}`
 * `license` Optional [SPDX License ID](https://spdx.org/licenses/)
 * `author` Optional string author name. Overrides any name extracted from `skill_id` or `source` URL
-* `extra_plugins` list of python requirements that are not direct dependencies of the skill but should be installed in a companion OVOS service
-* `name` is a human-readable name for the skill to be used in store listings, UI, etc.
-* `description` is a human-readable short description of the skill. This should be limited to one or two sentences max
-* `examples` is a list of example utterances that this skill should handle
-* `tags` is a list of arbitrary labels and categories, helps search results to find this skill
-* `icon` optional skill icon to display
-* `images` optional list of images to showcase the skill
-
-> Installation will generally follow the priority of `<pip_spec>` > `<package_name>` > `git+<source>`. At least one of these *MUST* be a valid installation option
+* `extra_plugins` Optional list of python requirements that are not direct dependencies of the skill but should be installed in a companion OVOS service
+* `name` Optional human-readable name for the skill to be used in store listings, UI, etc. Overrides any name extracted from `skill_id` or `source` URL
+* `description` Optional human-readable short description of the skill. This should be limited to one or two sentences max
+* `examples` Optional list of example utterances that this skill should handle
+* `tags` Optional list of arbitrary labels and categories, helps search results to find this skill
+* `icon` Optional skill icon to display
+* `images` Optional list of images to showcase the skill
 
 > **LANG SUPPORT**: include `skill.json` in each lang subfolder of your `locale` skill directory, this signals language support and allows translation of `name`, `description`, `examples` and `tags`
 
+# Installation
+Installation of a skill should generally follow the priority of `<pip_spec>` > `<package_name>` > `git+<source>`. At least one of these *MUST* be a valid installation option. A minimal exmple of
+skill installation in Python is included *for reference only*:
+
+```python
+import pip
+import json
+
+with open("skill.json") as f:
+    skill_spec = json.load(f)
+
+specs = [skill_spec.get('pip_spec')] if skill_spec.get('pip_spec') else []
+specs.append(skill_spec['package_name']
+if skill_spec.get('source'):
+    specs.append(f"git+{skill_spec['source']}")
+
+for spec in specs:
+    if pip.main(['install', spec) == 0:
+        # Successful installation
+        break
+```
+
+Note that this example does not account for existing packages and using it on its own could result in broken dependencies.


### PR DESCRIPTION
Extends skill.json to include (optionally) `pip_spec`, `license`, and `author`.
Marks `source` as optional as a skill installed from a local path or network share may not have an associated git URL